### PR TITLE
Gequire syro in Gemfile and fix readme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ gem 'cuba'
 gem 'sinatra'
 gem 'nyny'
 gem 'synfeld'
+gem 'syro'
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -10,8 +10,8 @@ nyny :: NYNY (https://github.com/alisnic/nyny)
 rack-app :: Rack::App (https://github.com/rack-app/rack-app)
 rails :: Ruby on Rails (http://rubyonrails.org/)
 roda :: Roda (http://roda.jeremyevans.net)
-sinatra :: Sinatra (http://www.sinatrarb.com/) 
-syro : Syro (http://soveran.github.io/syro/)
+sinatra :: Sinatra (http://www.sinatrarb.com/)
+syro :: Syro (http://soveran.github.io/syro/)
 synfeld :: Synfeld (https://github.com/swerling/synfeld)
 
 These frameworks are designed to be run with the default settings.


### PR DESCRIPTION
There was a problem with all syro apps: `'require': cannot load such file -- syro (LoadError)`. 
I've fixed it by adding syro to Gemfile.

Also there was a problem with syro in README.rdoc: a missing colon in a supported frameworks table. Also fixed.