### PR TITLE
Improve instructions for Hanami 2 beta

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -32,7 +32,8 @@ Roda, Cuba, or Hanami.
 After cloning the repository, install the related gems:
 
   gem install gruff # if you want to create the graphs
-  gem install rails roda cuba hanami # frameworks to test
+  gem install rails roda cuba # frameworks to test
+  gem install hanami-controller hanami-router --pre
 
 A Gemfile is not used, because all web frameworks are tested independently,
 and with a Gemfile, bundler assumes all gems must be able to work together.


### PR DESCRIPTION
The `hanami` gem no longer requires `hanami-router` and `hanami-controller`, so they must be installed manually. This is due to with Hanami 2 being a (heavily web-focused) general-purpose application framework, so now those gems are included in generated `Gemfile`s.

The `--pre` can be dropped once 2.0 is released properly.