### PR TITLE
Make Rails config more production like

### DIFF
--- a/builders/rails.rb
+++ b/builders/rails.rb
@@ -33,9 +33,10 @@ File.open("#{File.dirname(__FILE__)}/../apps/rails_#{LEVELS}_#{ROUTES_PER_LEVEL}
 # frozen-string-literal: true
 require 'action_controller/railtie'
 class App < Rails::Application
-  config.secret_token = '1234567890'*5
   config.secret_key_base = 'foo'
+  config.cache_classes = true
   config.eager_load = true
+  config.public_file_server.enabled = false
   config.active_support.deprecation = :stderr
   config.middleware.delete(ActionDispatch::ShowExceptions)
   config.middleware.delete(Rack::Lock)

--- a/static/builders/rails-minimal-middleware.rb
+++ b/static/builders/rails-minimal-middleware.rb
@@ -36,9 +36,10 @@ File.open("#{File.dirname(__FILE__)}/../apps/rails-minimal-middleware_#{LEVELS}_
 # frozen-string-literal: true
 require 'action_controller/railtie'
 class App < Rails::Application
-  config.secret_token = '1234567890'*5
   config.secret_key_base = 'foo'
+  config.cache_classes = true
   config.eager_load = true
+  config.public_file_server.enabled = false
   config.active_support.deprecation = :stderr
 
   config.middleware.delete(ActionDispatch::ShowExceptions)

--- a/static/builders/rails.rb
+++ b/static/builders/rails.rb
@@ -36,9 +36,10 @@ File.open("#{File.dirname(__FILE__)}/../apps/rails_#{LEVELS}_#{ROUTES_PER_LEVEL}
 # frozen-string-literal: true
 require 'action_controller/railtie'
 class App < Rails::Application
-  config.secret_token = '1234567890'*5
   config.secret_key_base = 'foo'
+  config.cache_classes = true
   config.eager_load = true
+  config.public_file_server.enabled = false
   config.active_support.deprecation = :stderr
   config.middleware.delete(ActionDispatch::ShowExceptions)
   config.middleware.delete(Rack::Lock)


### PR DESCRIPTION
These are all set by default in config/environments/production.rb for newly generated Rails apps.

See: https://github.com/rails/rails/blob/7163a132d2ee552c7e601665448d7f52f111c057/railties/lib/rails/generators/rails/app/templates/config/environments/production.rb.tt