### PR TITLE
Ensure that Rails routes are eager loaded

### DIFF
--- a/builders/rails.rb
+++ b/builders/rails.rb
@@ -3,7 +3,7 @@ rails_routes = lambda do |f, level, prefix, lvars|
   controller = prefix.gsub('/', '').gsub(/:\w/, '')
   ROUTES_PER_LEVEL.times do
     if level == 1
-      f.puts "  get '#{prefix}#{base}/:#{lvars.last}' => 'main##{controller}#{base}'"
+      f.puts "    get '#{prefix}#{base}/:#{lvars.last}' => 'main##{controller}#{base}'"
     else
       rails_routes.call(f, level-1, "#{prefix}#{base}/:#{lvars.last}/", lvars + [lvars.last.succ])
     end
@@ -44,6 +44,12 @@ class App < Rails::Application
   config.logger = Logger.new('/dev/null')
   config.logger.level = 4
   config.log_level = :error 
+  routes.append do
+END
+  rails_routes.call(f, LEVELS, '/', ['a'])
+  f.puts <<END
+    match '*unmatched', to: 'application#route_not_found', via: :all
+  end
 end
 class ApplicationController < ActionController::Base
   def route_not_found
@@ -55,11 +61,6 @@ END
   rails_controllers.call(f, LEVELS, '', ['a'])
   f.puts "end"
   f.puts "App.initialize!"
-  f.puts "App.routes.clear!"
-  f.puts "App.routes.draw do"
-  rails_routes.call(f, LEVELS, '/', ['a'])
-  f.puts "  match '*unmatched', to: 'application#route_not_found', via: :all"
-  f.puts "end"
 end
 
 


### PR DESCRIPTION
The Rails RouteSet is eagerly loaded at the end of initialization in the Finisher module. This ensure that things like Routes and Paths have their expensive work done ahead of time, like creating regular expressions for Paths to match against requests.

Previously, the Rails builder would clear routes after initialization and then draw the desired routes. Since the eager loading of routing objects happens during initialization, this leads to a slowdown during the first requests that have to build the routing objects.

This commit addresses this by adding the routes before initialization so that they can be properly eager loaded. The difference in rails_1_10.rb is not very large, however rps went from ~4k to ~5k for rails_4_10.rb

draw vs append:

My understanding is that Rails is hard coded during initialization to call #clear! on the RouteSet and then always try to load config/routes.rb. Therefore, we cannot use #draw because whatever we draw will be cleared, whereas appended routes are not cleared by #clear! While this isn't "default" Rails configuration, it seems like a reasonable solution for a single file Rails application that results in more accurate behavior.