### PR TITLE
Use Rails.application instead of App class

### DIFF
--- a/builders/rails.rb
+++ b/builders/rails.rb
@@ -32,7 +32,7 @@ File.open("#{File.dirname(__FILE__)}/../apps/rails_#{LEVELS}_#{ROUTES_PER_LEVEL}
   f.puts <<END
 # frozen-string-literal: true
 require 'action_controller/railtie'
-class App < Rails::Application
+class AppClass < Rails::Application
   config.secret_key_base = 'foo'
   config.cache_classes = true
   config.eager_load = true
@@ -59,8 +59,11 @@ end
 class MainController < ApplicationController
 END
   rails_controllers.call(f, LEVELS, '', ['a'])
-  f.puts "end"
-  f.puts "App.initialize!"
+  f.puts <<END
+end
+Rails.application.initialize!
+App = Rails.application
+END
 end
 
 


### PR DESCRIPTION
Since Rails::Application is a Rails::Railtie, methods like #call can be called on the class and it will delegate to the Application instance with #method_missing. However, this is not how Rails apps are configured by default. Rails apps have the following config.ru generated:

```ruby
require_relative "config/environment"

run Rails.application
Rails.application.load_server
```

So the actual object getting called will be the instance of the Application (Rails.application). Since the class to instance delegation adds overhead and isn't really accurate of a real world app, the App constant has been updated to refer to the instance.