### PR TITLE
Use latest `config.load_defaults` in Rails Apps

### DIFF
--- a/benchmarker.rb
+++ b/benchmarker.rb
@@ -94,6 +94,10 @@ unless (n = ENV['R10K_ITERATIONS'].to_i) > 0
 end
 n *= (10000.0/(routes_per_level ** levels)).ceil
 
+if defined?(RubyVM::YJIT.enable) && ENV.fetch('R10K_YJIT', 'true') == 'true'
+  RubyVM::YJIT.enable
+end
+
 if (warmup = ENV['R10K_WARMUP_ITERATIONS'].to_i) > 0
   warmup.times{run_routes.call}
 end

--- a/builders/rails.rb
+++ b/builders/rails.rb
@@ -33,6 +33,8 @@ File.open("#{File.dirname(__FILE__)}/../apps/rails_#{LEVELS}_#{ROUTES_PER_LEVEL}
 # frozen-string-literal: true
 require 'action_controller/railtie'
 class AppClass < Rails::Application
+  config.load_defaults Rails::VERSION::STRING.to_f
+  config.yjit = false
   config.secret_key_base = 'foo'
   config.cache_classes = true
   config.eager_load = true


### PR DESCRIPTION
Most applications should be using the more modern defaults, so this makes the benchmark more realistic.

Note: this sets `config.yjit = true` which will enable YJIT automatically after the application is initialized (so that boot code is never compiled). Perhaps to be more "fair" this should be disabled and an ENV var could be added to the benchmarker that does something similar in between booting and running requests?