### PR TITLE
Use `ShowExceptions` to handle 404s

### DIFF
--- a/builders/rails.rb
+++ b/builders/rails.rb
@@ -44,7 +44,6 @@ class AppClass < Rails::Application
   config.eager_load = true
   config.public_file_server.enabled = false
   config.active_support.deprecation = :stderr
-  config.middleware.delete(ActionDispatch::ShowExceptions)
   config.middleware.delete(Rack::Lock)
   config.middleware.use(Rack::ContentLength)
   config.logger = Logger.new('/dev/null')
@@ -54,13 +53,9 @@ class AppClass < Rails::Application
 END
   rails_routes.call(f, LEVELS, '/', ['a'])
   f.puts <<END
-    match '*unmatched', to: 'application#route_not_found', via: :all
   end
 end
 class ApplicationController < ActionController::Base
-  def route_not_found
-    head 404
-  end
 end
 class MainController < ApplicationController
 END


### PR DESCRIPTION
This aligns the Rails benchmark more closely with the default configuration of applications.

For the "why", `*unmatched` hits a pathological case in Rails' router where it ends up doing lots of `match?`ing and `slice`ing due to the path being a Regexp that can cross the `/.?` boundaries that the Router splits strings on. Since the "more realistic" configuration avoids this pathological case, it seems like a good change to make.